### PR TITLE
Configure Git to normalize line endings.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure normalized line endings
+* text=auto


### PR DESCRIPTION
This configures Git to normalize line endings using a `.gitattributes` file.